### PR TITLE
Fixed "Can't find file or directory" on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This command line tool is an easy way to migrate your existing Cordova based (including Ionic) projects over to use Crosswalks Chromium webview. The performance benefit is huge, you get access to all the latest web APIs, and the only major draw back is increased apk size.
 
 ### Version
-0.3.3
+0.3.4
 
 ### Installation
 

--- a/bin/cordova-android-crosswalk
+++ b/bin/cordova-android-crosswalk
@@ -325,14 +325,15 @@ var Runtime = {
    */
   buildFinal: function() {
     var pathCmd = Runtime.isWin ? 'SET' : 'export';
+    var removeCmd = Runtime.isWin ? ' rd /S /Q ' : ' rm -Rf ';
     var commands = pathCmd +
     ' ANDROID_HOME=$(dirname $(dirname $(which android))) &&' +
     ' cd platforms/android/CordovaLib/ &&' +
     ' android update project --subprojects --path . --target "' + Runtime.Args.target + '" &&' +
     ' ant debug &&' +
     ' cd .. &&' +
-    ' rm -Rf ant-gen &&' +
-    ' rm -Rf ant-build';
+    removeCmd + ' ant-gen &&' +
+    removeCmd + ' ant-build';
 
     // Executes the custom tidy up commands
     exec(commands)

--- a/bin/cordova-android-crosswalk
+++ b/bin/cordova-android-crosswalk
@@ -325,7 +325,7 @@ var Runtime = {
    */
   buildFinal: function() {
     var pathCmd = Runtime.isWin ? 'SET' : 'export';
-    var removeCmd = Runtime.isWin ? ' rd /S /Q ' : ' rm -Rf ';
+    var removeCmd = Runtime.isWin ? ' IF EXIST rd /S /Q ' : ' rm -Rf ';
     var commands = pathCmd +
     ' ANDROID_HOME=$(dirname $(dirname $(which android))) &&' +
     ' cd platforms/android/CordovaLib/ &&' +

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-android-crosswalk",
   "description": "Automagically migrates your Cordova Android projects so they use Crosswalks Chromium webview.",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "homepage": "https://github.com/tylerbuchea/cordova-android-crosswalk",
   "author": {
     "name": "Tyler Buchea",


### PR DESCRIPTION
It was unable to run on Windows, 'cause rm -Rf command does not exists.